### PR TITLE
Using own cycle because of problem with eventlet module and internal …

### DIFF
--- a/DataStreamer.py
+++ b/DataStreamer.py
@@ -17,12 +17,13 @@ class DataStreamer:
             def __init__(self, socketio):
                 self._socketio = socketio
                 print("reaches here...")
-                self._revpi = revpimodio2.RevPiModIO(autorefresh=True, debug=True) # this line hangs
+                self._revpi = revpimodio2.RevPiModIO(debug=True) # this line hangs with autorefresh=True
                 print("never reaches here when above line is not commented out...")
 
             def _cycle_program(self, ct):
-                new_data = randint(-500, 500)/100
-                # new_data = self._revpi.io.InputValue_1.value/1000
+                self._revpi.readprocimg()  # Read all input values from process image
+                # new_data = randint(-500, 500)/100
+                new_data = self._revpi.io.InputValue_1.value / 1000
                 self._socketio.emit("new_data", {"data" : new_data})
 
             def produce(self):


### PR DESCRIPTION
There is something with the "eventlet" module... ModIO will create a internal thread if you are using `autorefresh=True`. Something in the eventlet module will do something which wait for the end of the internal ModIO thread... This will never happen. If I remove the eventlet things, we will reach the "never reaches here when above line is not commented out..." line...

Maybe you have to create a own cycle without the autorefresh and internal cycleloop...

This will work so far...